### PR TITLE
Fixed quotation error in Keyword Search

### DIFF
--- a/Catfish/Scripts/solrQueryParser.js
+++ b/Catfish/Scripts/solrQueryParser.js
@@ -319,9 +319,9 @@ var SolrParser = function (langCode) {
                 case "\"":
                     var value = decodeQuotation.call(this, tokens);
                     if (name == null) {
-                        name = "\"" + token + "\"";
+                        name = "\"" + value + "\"";
                     } else {
-                        name += " " + "\"" + token + "\"";
+                        name += " " + "\"" + value + "\"";
                     }
                     break;
 


### PR DESCRIPTION
Updated the Solr decoder to handle quotations in the keyword search. Previously it only returned the first quotion.